### PR TITLE
make sure the paths and cwd are handled properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ module.exports = function () {
 
         this.push(new gutil.File({
           contents: new Buffer(data),
-          path: path.relative('.', entry.props.path)
+          path: path.normalize(path.dirname(file.path) + '/' + entry.props.path),
+          base: file.base,
+          cwd: file.cwd
         }))
       }.bind(this)))
     }.bind(this))

--- a/test.js
+++ b/test.js
@@ -15,13 +15,13 @@ describe('gulp-untar', function () {
     }, function () {
       assert.equal(files.length, 2)
 
-      var file1 = _.find(files, {path: 'file1.txt'})
-      assert.ok(file1, 'No file found named "file1.txt"')
+      var file1 = _.find(files, {path: 'fixtures/file1.txt', base: './fixtures', cwd: '.'})
+      assert.ok(file1, 'No file found named "fixtures/file1.txt"')
       assert.ok(file1.isBuffer(), 'Expected buffer')
       assert.equal('File 1\n', file1.contents.toString())
 
-      var file2 = _.find(files, {path: 'dir1/file2.txt'})
-      assert.ok(file2, 'No file found named "dir1/file2.txt"')
+      var file2 = _.find(files, {path: 'fixtures/dir1/file2.txt', base: './fixtures', cwd: '.'})
+      assert.ok(file2, 'No file found named "fixtures/dir1/file2.txt"')
       assert.ok(file2.isBuffer(), 'Expected buffer')
       assert.equal('File 2\n', file2.contents.toString())
 
@@ -37,6 +37,8 @@ describe('gulp-untar', function () {
 
       stream.write(new gutil.File({
         path: './fixtures/test.tar',
+        base: './fixtures',
+        cwd: '.',
         contents: fs.createReadStream('./fixtures/test.tar')
       }))
 
@@ -53,6 +55,8 @@ describe('gulp-untar', function () {
 
       stream.write(new gutil.File({
         path: './fixtures/test.tar',
+        base: './fixtures',
+        cwd: '.',
         contents: fs.readFileSync('./fixtures/test.tar')
       }))
 
@@ -71,6 +75,8 @@ describe('gulp-untar', function () {
 
       stream.write(new gutil.File({
         path: './fixtures/test.tar',
+        base: './fixtures',
+        cwd: '.',
         contents: null
       }))
     })


### PR DESCRIPTION
We were having an issue with piping multiple tarballs in multiple directories which needed to keep their relative paths

cwd/from/folder/mine.tar
cwd/from/sub/folder/theirs.tar

gulp.src('./from/**/*.tar')
  .pipe(untar())
  .pipe(gulp.dest './deploy')

would end up dropping the folder and sub/folders from the above, instead of keeping the folders in the glob.
This patch fixes that issue