### PR TITLE
"event-stream" can't be a dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "gulp-util": "~2.2.14",
     "through2": "~0.4.1",
     "streamifier": "~0.1.0",
-    "tar": "~0.1.19"
+    "tar": "~0.1.19",
+    "event-stream": "~3.1.5"
   },
   "devDependencies": {
-    "event-stream": "~3.1.5",
     "mocha": "~1.18.2",
     "lodash": "~2.4.1",
     "jshint": "~2.5.0"


### PR DESCRIPTION
"event-stream" can't be a dev dependency because then this plugin will brake when you are installing it directly. Either with `npm install gulp-untar` or running npm install in a directory not containing the package.json file.

See more on dev vs. regular dependencies here: http://stackoverflow.com/a/22004559/1465640