### PR TITLE
Add baseDir parameter to assign base directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var path = require('path')
 var streamifier = require('streamifier')
 var es = require('event-stream')
 
-module.exports = function () {
+module.exports = function (baseDir) {
   return through.obj(function (file, enc, callback) {
     var contentsStream
 
@@ -40,7 +40,7 @@ module.exports = function () {
         this.push(new gutil.File({
           contents: new Buffer(data),
           path: path.normalize(path.dirname(file.path) + '/' + entry.props.path),
-          base: file.base,
+          base: path.resolve(baseDir || file.base),
           cwd: file.cwd
         }))
       }.bind(this)))


### PR DESCRIPTION
When I use gulp-untar, there is no way to assign base directory.
I want to remove the first folder of `entry.props.path`.
e.g.
entry.props.path = 'first_folder/second_folder/filename.ext'
I just want to untar the file with name 'second_folder/filename.ext'.
I must assing file.base = path.resolve('./first_folder') to achieve this goal.

I just add a parameter `baseDir`, and assign it to the base option of gutil.File.