### PR TITLE
Uplevel tar dep to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Extract tarballs in your gulp build pipeline",
   "main": "index.js",
   "dependencies": {
+    "event-stream": "~3.1.5",
     "gulp-util": "~2.2.14",
-    "through2": "~0.4.1",
     "streamifier": "~0.1.0",
-    "tar": "~0.1.19",
-    "event-stream": "~3.1.5"
+    "tar": "^1.0.3",
+    "through2": "~0.4.1"
   },
   "devDependencies": {
     "mocha": "~1.18.2",


### PR DESCRIPTION
This upgrades the transitive dep graceful-fs@3 to v4 which gets around the
breakage caused by: https://github.com/nodejs/node/pull/6413

---

More context in https://github.com/Microsoft/vscode-extension-vscode/issues/28, the tests pass fine afterwards (that's the extent of my testing).