### PR TITLE
removing deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var through = require('through2')
 var parse = require('tar').Parse
-var gutil = require('gulp-util')
+var Vinyl = require('vinyl')
 var path = require('path')
 var streamifier = require('streamifier')
 var es = require('event-stream')
@@ -37,7 +37,7 @@ module.exports = function () {
       entry.pipe(es.wait(function (err, data) {
         if (err) return this.emit('error', err)
 
-        this.push(new gutil.File({
+        this.push(new Vinyl({
           contents: new Buffer(data),
           path: path.normalize(path.dirname(file.path) + '/' + entry.props.path),
           base: file.base,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "streamifier": "~0.1.1",
     "tar": "^2.2.1",
     "through2": "~2.0.3",
-    "vinyl": "^2.1.0"
+    "vinyl": "^1.2.0"
   },
   "devDependencies": {
     "mocha": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "gulp-untar",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Extract tarballs in your gulp build pipeline",
   "main": "index.js",
   "dependencies": {
     "event-stream": "~3.3.4",
-    "gulp-util": "~3.0.8",
     "streamifier": "~0.1.1",
     "tar": "^2.2.1",
-    "through2": "~2.0.3"
+    "through2": "~2.0.3",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "mocha": "~3.2.0",

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var gutil = require('gulp-util')
+var Vinyl = require('vinyl')
 var assert = require('assert')
 var fs = require('fs')
 var _ = require('lodash')
@@ -35,7 +35,7 @@ describe('gulp-untar', function () {
 
       stream.pipe(assertOutput(done))
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         path: './fixtures/test.tar',
         base: './fixtures',
         cwd: '.',
@@ -53,7 +53,7 @@ describe('gulp-untar', function () {
 
       stream.pipe(assertOutput(done))
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         path: './fixtures/test.tar',
         base: './fixtures',
         cwd: '.',
@@ -73,7 +73,7 @@ describe('gulp-untar', function () {
         done()
       })
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         path: './fixtures/test.tar',
         base: './fixtures',
         cwd: '.',


### PR DESCRIPTION
Fixes https://github.com/jmerrifield/gulp-untar/issues/11


Replace deprecated dependency gulp-util

gulp-util has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the latest release of Gulp 4 so it is important to replace gulp-util.

The README.md lists alternatives for all the components so a simple replacement should be enough.

Your package is popular but still relying on gulp-util, it would be good to publish a fixed version to npm as soon as possible.

See:

https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
gulpjs/gulp-util#143